### PR TITLE
Don't use server-dir argument for path that sync-state is uploaded to

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -389,7 +389,7 @@ async function syncLocalToServer(client: ftp.Client, diffs: DiffResult, logger: 
   logger.all(`----------------------------------------------------------------`);
   logger.all(`🎉 Sync complete. Saving current server state to "${args["server-dir"] + args["state-name"]}"`);
   if (args["dry-run"] === false) {
-    await retryRequest(logger, async () => await client.uploadFrom(args["local-dir"] + args["state-name"], args["server-dir"] + args["state-name"]));
+    await retryRequest(logger, async () => await client.uploadFrom(args["local-dir"] + args["state-name"], args["state-name"]));
   }
 }
 


### PR DESCRIPTION
When using the `server-dir` argument, sync-state tries to nest the file twice and therefore fails (as the folder doesn't exists I'm assuming). This simply removes the `server-dir` arg from the path that the sync-state file is trying to be uploaded to.

This fixes the issue I am having as documented here: https://github.com/SamKirkland/FTP-Deploy-Action/issues/120