### PR TITLE
Fix incorrect boolean check for calculating rejectUnauthorized

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -266,7 +266,7 @@ async function connect(client: ftp.Client, args: IFtpDeployArgumentsWithDefaults
 
   client.ftp.verbose = args["log-level"] === "verbose";
 
-  const rejectUnauthorized = args.security === "loose";
+  const rejectUnauthorized = args.security === "strict";
 
   await client.access({
     host: args.server,


### PR DESCRIPTION
This check is currently doing the opposite of what is supposed to. It should be rejecting unauthorized domains when 'strict' is set as the security mode.