### PR TITLE
Fixed the 550 Errors that sometimes happen when deploying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# VSCode workspace settings
+.vscode

--- a/src/syncProvider.ts
+++ b/src/syncProvider.ts
@@ -144,8 +144,12 @@ export class FTPSyncProvider implements ISyncProvider {
             }
         }
 
-        // navigate back to the root folder
-        await this.upDir(path.folders?.length);
+        try {
+            // navigate back to the root folder
+            await this.upDir(path.folders?.length);
+        } catch (e) {
+            this.logger.all(`Error navigating up a folder when removing ${folderPath}`)
+        }        
 
         this.logger.verbose(`  completed`);
     }

--- a/src/syncProvider.ts
+++ b/src/syncProvider.ts
@@ -139,7 +139,7 @@ export class FTPSyncProvider implements ISyncProvider {
                     
                     await retryRequest(this.logger, async () => await this.client.removeDir(path.folders!.join("/") + "/"));
                 } catch (e) {
-                    this.logger.all(`Error 550removing folder ${folderPath}. Skipping...`)
+                    this.logger.all(`Error 550 removing folder ${folderPath}. Skipping...`)
                 }
             }
         }
@@ -210,7 +210,8 @@ export class FTPSyncProvider implements ISyncProvider {
         this.logger.all(`----------------------------------------------------------------`);
         this.logger.all(`🎉 Sync complete. Saving current server state to "${this.serverPath + this.stateName}"`);
         if (this.dryRun === false) {
-            await retryRequest(this.logger, async () => await this.client.uploadFrom(this.localPath + this.stateName, this.stateName));
+            await retryRequest(this.logger, async () => await this.removeFile(this.stateName));
+            await retryRequest(this.logger, async () => await this.uploadFile(this.stateName, "replace"));
         }
     }
 }


### PR DESCRIPTION
Added some try catch blocks and other measures to catch out 550 errors like in these issues: 
https://github.com/SamKirkland/FTP-Deploy-Action/issues/220
https://github.com/SamKirkland/FTP-Deploy-Action/issues/218
https://github.com/SamKirkland/FTP-Deploy-Action/issues/214

When using the action for my website I'd get build fails because the action would try to remove a non existent file, or add a file to a directory that didn't exist etc.

It has been linted and tested and I also used it to upload my website and it worked as desired.


