### PR TITLE
Allow to set FTP timeout through options.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@samkirkland/ftp-deploy",
-  "version": "1.1.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samkirkland/ftp-deploy",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": false,
   "description": "Deploy files to a ftp server",
   "main": "dist/module.js",

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -125,7 +125,7 @@ export async function deploy(args: IFtpDeployArgumentsWithDefaults, logger: ILog
 
     createLocalState(localFiles, logger, args);
 
-    const client = new ftp.Client();
+    const client = new ftp.Client(args.timeout);
 
     global.reconnect = async function () {
         timings.start("connecting");

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,5 @@
 import { HashDiff } from "./HashDiff";
-import { IFileList, currentSyncFileVersion, IFile } from "./types";
+import { IFileList, currentSyncFileVersion, IFile, IFtpDeployArgumentsWithDefaults } from "./types";
 import { Record } from "./types";
 import { applyExcludeFilter, getDefaultSettings, ILogger, Timings } from "./utilities";
 import path from "path";
@@ -701,6 +701,69 @@ describe("getLocalFiles", () => {
         const filteredStats = files.filter(file => applyExcludeFilter(file, ["test/folder/**"]));
 
         expect(filteredStats.map(f => f.path)).toStrictEqual(["test/test.js"]);
+    });
+});
+
+
+describe("getDefaultSettings", () => {
+    test("path validation", async () => {
+        expect(() => getDefaultSettings({
+            server: "a",
+            username: "b",
+            password: "c",
+            "local-dir": "noEndingSlash"
+        })).toThrowError("local-dir should be a folder (must end with /)");
+
+        expect(() => getDefaultSettings({
+            server: "a",
+            username: "b",
+            password: "c",
+            "server-dir": "noEndingSlash"
+        })).toThrowError("server-dir should be a folder (must end with /)");
+    });
+
+    test("verify default settings", async () => {
+        expect(getDefaultSettings({
+            server: "a",
+            username: "b",
+            password: "c",
+        })).toEqual({
+            server: "a",
+            username: "b",
+            password: "c",
+            port: 21,
+            protocol: "ftp",
+            "local-dir": "./",
+            "server-dir": "./",
+            "state-name": ".ftp-deploy-sync-state.json",
+            "dry-run": false,
+            "dangerous-clean-slate": false,
+            exclude: excludeDefaults,
+            "log-level": "standard",
+            security: "loose",
+            timeout: 30000
+        });
+    });
+
+    test("verify default settings override", async () => {
+        const customSettings: IFtpDeployArgumentsWithDefaults = {
+            server: "a",
+            username: "b",
+            password: "c",
+            port: 54321,
+            protocol: "ftps-legacy",
+            "local-dir": "./client/",
+            "server-dir": "./server/",
+            "state-name": ".customState.json",
+            "dry-run": true,
+            "dangerous-clean-slate": true,
+            exclude: [],
+            "log-level": "verbose",
+            security: "strict",
+            timeout: 1234
+        };
+
+        expect(getDefaultSettings(customSettings)).toEqual(customSettings);
     });
 });
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -589,6 +589,7 @@ describe("getLocalFiles", () => {
             exclude: [],
             "log-level": "standard",
             security: "loose",
+            timeout: 30000,
         });
 
         const mainYamlDiff = localDirDiffs.data.find(diff => diff.name === "workflows/main.yml")! as IFile;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,10 +64,9 @@ export interface IFtpDeployArguments {
 
     /**
      * Timeout in milliseconds for FTP operations as handled by underlying basic-ftp connection library.
-     * 
-     * Defaults to 30000 milliseconds (30s).
+     * @default 30000 (30 seconds)
      */
-    timeout?: 30000;
+    timeout?: number;
 }
 
 export interface IFtpDeployArgumentsWithDefaults {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,10 +57,17 @@ export interface IFtpDeployArguments {
      * When using protocol "ftps" or "ftps-legacy" should the cert name need to match exactly?
      * Set this to "strict" to ensure your data is being encrypted
      * 
-     * Defautls to loose because of the sheer volume of shared hosts that give ftp domains a cert without a matching common name
+     * Defaults to loose because of the sheer volume of shared hosts that give ftp domains a cert without a matching common name
      * @default "loose"
      */
     security?: "strict" | "loose";
+
+    /**
+     * Timeout in milliseconds for FTP operations as handled by underlying basic-ftp connection library.
+     * 
+     * Defaults to 30000 milliseconds (30s).
+     */
+    timeout?: 30000;
 }
 
 export interface IFtpDeployArgumentsWithDefaults {
@@ -77,6 +84,7 @@ export interface IFtpDeployArgumentsWithDefaults {
     exclude: string[];
     "log-level": "minimal" | "standard" | "verbose";
     security: "strict" | "loose";
+    timeout: number;
 }
 
 export interface IFile {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -188,7 +188,7 @@ export function getDefaultSettings(withoutDefaults: IFtpDeployArguments): IFtpDe
         "exclude": withoutDefaults.exclude ?? excludeDefaults,
         "log-level": withoutDefaults["log-level"] ?? "standard",
         "security": withoutDefaults.security ?? "loose",
-        "timeout": withoutDefaults.timeout ?? 30000
+        "timeout": withoutDefaults.timeout ?? 30000,
     };
 }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -188,6 +188,7 @@ export function getDefaultSettings(withoutDefaults: IFtpDeployArguments): IFtpDe
         "exclude": withoutDefaults.exclude ?? excludeDefaults,
         "log-level": withoutDefaults["log-level"] ?? "standard",
         "security": withoutDefaults.security ?? "loose",
+        "timeout": withoutDefaults.timeout ?? 30000
     };
 }
 


### PR DESCRIPTION
I have to deal with deploying to a very slow FTP server. I've added a way of setting the timeout of the underlying FTP client instance through an option.