### PR TITLE
Fixing folder 550 delete action

### DIFF
--- a/src/syncProvider.ts
+++ b/src/syncProvider.ts
@@ -50,7 +50,7 @@ export class FTPSyncProvider implements ISyncProvider {
 
     /**
      * Converts a file path (ex: "folder/otherfolder/file.txt") to an array of folder and a file path
-     * @param fullPath 
+     * @param fullPath
      */
     private getFileBreadcrumbs(fullPath: string): IFilePath {
         // todo see if this regex will work for nonstandard folder names
@@ -128,7 +128,17 @@ export class FTPSyncProvider implements ISyncProvider {
         this.logger.all(`removing folder "${absoluteFolderPath}"`);
 
         if (this.dryRun === false) {
-            await retryRequest(this.logger, async () => await this.client.removeDir(absoluteFolderPath));
+            try {
+                await retryRequest(this.logger, async () => await this.client.removeDir(absoluteFolderPath));
+            }
+            catch (e: any) {
+                if (e.code === ErrorCode.FileNotFoundOrNoAccess) {
+                    this.logger.standard("Directory not found or you don't have access to the file - skipping...");
+                }
+                else {
+                    throw e;
+                }
+            }
         }
 
         this.logger.verbose(`  completed`);

--- a/src/syncProvider.ts
+++ b/src/syncProvider.ts
@@ -110,7 +110,7 @@ export class FTPSyncProvider implements ISyncProvider {
             }
             catch (e: any) {
                 // this error is common when a file was deleted on the server directly
-                if (e.code === ErrorCode.FileNotFoundOrNoAccess) {
+                if (e?.code === ErrorCode.FileNotFoundOrNoAccess) {
                     this.logger.standard("File not found or you don't have access to the file - skipping...");
                 }
                 else {
@@ -132,7 +132,7 @@ export class FTPSyncProvider implements ISyncProvider {
                 await retryRequest(this.logger, async () => await this.client.removeDir(absoluteFolderPath));
             }
             catch (e: any) {
-                if (e.code === ErrorCode.FileNotFoundOrNoAccess) {
+                if (e?.code === ErrorCode.FileNotFoundOrNoAccess) {
                     this.logger.standard("Directory not found or you don't have access to the file - skipping...");
                 }
                 else {


### PR DESCRIPTION
This pull request improves **error handling when removing directories** during FTP operations. In certain cases, the target directory may already be unavailable (e.g., deleted, renamed, or removed by a build process). Instead of throwing an exception, the process now logs a **warning** informing the user that the directory could not be removed or accessed.

This approach ensures that the **state file remains in sync** and avoids breaking deployments that rely on the `SamKirkland/FTP-Deploy-Action` GitHub Action.

### Summary of Changes
- **Improved Error Handling:**
  - Replaces exceptions with warnings when directories cannot be removed.
- **Deployment Reliability:**
  - Keeps the state file consistent even if some directories are missing.
  - Prevents deployments from failing due to non-critical directory removal issues.